### PR TITLE
feat(raster): Add brightness, contrast, and saturation values

### DIFF
--- a/src/main/xsd/state/1.0.0/state.xsd
+++ b/src/main/xsd/state/1.0.0/state.xsd
@@ -514,6 +514,34 @@
         </xs:annotation>
       </xs:element>
 
+      <xs:element name="brightness" type="xs:decimal" minOccurs="0"
+        maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en" xml:space="preserve">
+            Brightness for raster layers from -1 (black), to 1 (white). 0 is unchanged.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="contrast" type="xs:decimal" minOccurs="0"
+        maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en" xml:space="preserve">
+            Contrast for raster layers from 0 to 2
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="saturation" type="xs:decimal" minOccurs="0"
+        maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en" xml:space="preserve">
+            Saturation for raster layers from 0 to 1
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+
       <xs:element name="lobBearingColumn" type="xs:token" minOccurs="0"
         maxOccurs="1">
         <xs:annotation>


### PR DESCRIPTION
This is related to ngageoint/opensphere#273 and fixes a couple of the XSD tests there.