### PR TITLE
feat(layer): add contentType property to layer options

### DIFF
--- a/src/main/xsd/state/1.0.0/state.xsd
+++ b/src/main/xsd/state/1.0.0/state.xsd
@@ -1250,6 +1250,14 @@
         </xs:annotation>
       </xs:element>
 
+      <xs:element name="contentType" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en" xml:space="preserve">
+            The Content-Type header value to use for HTTP POST requests made by this layer.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
       <xs:element name="usePost" type="xs:boolean" minOccurs="0"
         maxOccurs="1">
         <xs:annotation>


### PR DESCRIPTION
This property is added to WFS layers to control the Content-Type header in POST requests.